### PR TITLE
Documentar estado actual del simulador de dominó

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Simulador de mesas de dominó
+
+## Estado actual del proyecto
+- El núcleo está implementado en `domino.c`, que modela partidas simultáneas de dominó con hasta cuatro jugadores por mesa y una cola global de acciones protegida con mutex/condición. El estado de cada mesa conserva el tren de fichas, manos de los jugadores, pozo, política de planificación y sincronización necesaria para coordinar hilos.
+- Cada mesa inicia hilos de jugadores productores, un planificador específico de mesa y se integra con un validador único que aplica exactamente una acción por turno antes de despachar al siguiente jugador según la política elegida.
+- Hay soporte para cuatro políticas de planificación (FCFS, RR, SJF_POINTS y SJF_PLAYERS) seleccionables en caliente mediante un hilo de control que también permite ajustar el quantum asociado al modo RR o consultar el estado de las mesas.
+- El flujo principal pide cuántas mesas crear, inicializa su estado con jugadores aleatorios, lanza todos los hilos auxiliares (validador y consola de control) y espera a que las mesas terminen para liberar recursos.
+
+## Cómo compilar
+Compila el ejecutable con GCC y la librería de hilos de POSIX:
+
+```bash
+gcc domino.c -lpthread -o domino
+```
+
+## Cómo ejecutar
+Ejecuta el binario generado y responde al prompt inicial indicando cuántas mesas quieres simular. Durante la ejecución puedes interactuar con la consola de control escribiendo `show`, `policy <mesa|all> <POLÍTICA>` o `quantum <mesa|all> <ms>` para modificar el planificador en caliente.


### PR DESCRIPTION
## Summary
- document the current architecture and runtime controls of the domino simulator in the README
- add compilation and execution instructions for the existing program

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2e409a03c8331987dff41edbd52c5